### PR TITLE
Default to image without a media query when no media queries match

### DIFF
--- a/packages/gatsby-image/src/__tests__/index.js
+++ b/packages/gatsby-image/src/__tests__/index.js
@@ -33,8 +33,8 @@ const fixedImagesShapeMock = [
     base64: `string_of_base64`,
   },
   {
-    width: 100,
-    height: 100,
+    width: 300,
+    height: 300,
     src: `test_image_2.jpg`,
     srcSet: `some other srcSet`,
     srcSetWebp: `some other srcSetWebp`,
@@ -121,6 +121,7 @@ const setupImages = (
 describe(`<Image />`, () => {
   const OLD_MATCH_MEDIA = window.matchMedia
   beforeEach(() => {
+    // None of the media conditions above match.
     window.matchMedia = jest.fn(media =>
       media === `only screen and (min-width: 1024px)`
         ? {
@@ -277,6 +278,48 @@ describe(`<Image />`, () => {
     const aspectPreserver = container.querySelector(`div div`)
     expect(aspectPreserver.getAttribute(`style`)).toEqual(
       expect.stringMatching(/width: 1024px; height: 768px;/)
+    )
+  })
+
+  it(`should select the image with no media query as mocked image of fluid variants provided.`, () => {
+    const { container } = render(
+      <Image
+        backgroundColor
+        className={`fluidArtDirectedImage`}
+        style={{ display: `inline` }}
+        title={`Title for the image`}
+        alt={`Alt text for the image`}
+        crossOrigin={`anonymous`}
+        fluid={fluidImagesShapeMock.slice().reverse()}
+        itemProp={`item-prop-for-the-image`}
+        placeholderStyle={{ color: `red` }}
+        placeholderClassName={`placeholder`}
+      />
+    )
+    const aspectPreserver = container.querySelector(`div div div`)
+    expect(aspectPreserver.getAttribute(`style`)).toEqual(
+      expect.stringMatching(/padding-bottom: 75%/)
+    )
+  })
+
+  it(`should select the image with no media query as mocked image of fixed variants provided.`, () => {
+    const { container } = render(
+      <Image
+        backgroundColor
+        className={`fixedArtDirectedImage`}
+        style={{ display: `inline` }}
+        title={`Title for the image`}
+        alt={`Alt text for the image`}
+        crossOrigin={`anonymous`}
+        fixed={fixedImagesShapeMock.slice().reverse()}
+        itemProp={`item-prop-for-the-image`}
+        placeholderStyle={{ color: `red` }}
+        placeholderClassName={`placeholder`}
+      />
+    )
+    const aspectPreserver = container.querySelector(`div div`)
+    expect(aspectPreserver.getAttribute(`style`)).toEqual(
+      expect.stringMatching(/width: 100px; height: 100px;/)
     )
   })
 

--- a/packages/gatsby-image/src/index.js
+++ b/packages/gatsby-image/src/index.js
@@ -91,8 +91,15 @@ const getCurrentSrcData = currentData => {
     if (foundMedia !== -1) {
       return currentData[foundMedia]
     }
+
+    // No media matches, select first element without a media condition
+    const noMedia = currentData.findIndex(
+      image => typeof image.media === `undefined`
+    )
+    if (noMedia !== -1) {
+      return currentData[noMedia]
+    }
   }
-  // Else return the first image.
   return currentData[0]
 }
 


### PR DESCRIPTION
window.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
